### PR TITLE
Fix/hr stay on profile 244

### DIFF
--- a/onboarding/src/Components/UserEdit/UserEditForm.js
+++ b/onboarding/src/Components/UserEdit/UserEditForm.js
@@ -75,9 +75,9 @@ function UserEditForm({ user, enableUploadAvatar, buttonTitle, modalTitle, editL
 
 
     const showModal = (message, out) => {
-        if(out){
+        if(out && setEditLoggedUser == null){
             let linkObj;
-            location.pathname === "/profile/manager"
+            location.pathname === "/my_profile"
                 ? linkObj = {to: "/"}
                 : linkObj = {to: "/user_list"}
             setModal(<ModalWarning handleAccept={ function(){} } title={ modalTitle } message={ message } id={ 0 } show={ true } acceptText={ "Ok" } link={ linkObj } />);
@@ -101,7 +101,7 @@ function UserEditForm({ user, enableUploadAvatar, buttonTitle, modalTitle, editL
     		</div>
 
     		<div className="col container-sm">
-    			<UserProfileManage
+    		    <UserProfileManage
                     user={ user }
                     handleSaveEdit={ handleSaveEdit }
                     showMessage={ showModal }

--- a/onboarding/src/Components/UserEdit/UserEditForm.js
+++ b/onboarding/src/Components/UserEdit/UserEditForm.js
@@ -6,6 +6,18 @@ import { useLocation } from "react-router-dom";
 import { validateURL } from "../utils";
 
 
+/**
+ * Returns component containing 2 parts: block of avatar and block with form inputs;
+ *
+ * @param user:  object of user to be edited with keys like  "id", "avatar", "department", "email", "first_name", "last_name", "location", "position", "tel";
+ * @param enableUploadAvatar:  boolean telling if avatar-image can be changed or not;
+ * @param buttonTitle:  text printed on button which is clicked when one wants to submit data;
+ * @param modalTitle:  text of header on modal;
+ * @param editLoggedUser:  number of state of component to update a page when user edits his own data, otherwise 'undefined';
+ * @param setEditLoggedUser:  function to change the number above and so the state of component;
+ * @returns {JSX.Element}
+ * @constructor
+ */
 function UserEditForm({ user, enableUploadAvatar, buttonTitle, modalTitle, editLoggedUser, setEditLoggedUser }) {
     const fileNameRef = useRef("");
     const location = useLocation();
@@ -16,7 +28,7 @@ function UserEditForm({ user, enableUploadAvatar, buttonTitle, modalTitle, editL
         user.avatar = validateURL(user.avatar, "/onboarding/static/images/unknown-profile.jpg");
         updateImageLink(user.avatar || "/onboarding/static/images/unknown-profile.jpg");
     },[user.avatar]);
-    
+
     const changeAvatar = function(e){
     	if(fileNameRef.current.files.length > 0){
     	    if(FileReader){
@@ -28,7 +40,7 @@ function UserEditForm({ user, enableUploadAvatar, buttonTitle, modalTitle, editL
     	    }
     	}
     };
-    
+
     let imageBox = <img src={ user.avatar || "/onboarding/static/images/unknown-profile.jpg" } alt="avatar" />;
     if(enableUploadAvatar){
         imageBox = (
@@ -72,10 +84,11 @@ function UserEditForm({ user, enableUploadAvatar, buttonTitle, modalTitle, editL
         } else
             setModal(<ModalWarning handleAccept={ hideModal } title={ modalTitle } message={ message } id={ 0 } show={ true } acceptText={ "Ok" } />);
     };
-    
+
     const hideModal = function(){
         setModal(<></>);
     };
+
 
     return (
     	<div className="row flex-column flex-md-row justify-content-center p-3">


### PR DESCRIPTION
After this merge
when HR will edit his own data and save/send,
he will stay on profile page (no moving into list of employees).
An option to move into main page is still kept but `url` of managers page is fixed.
  
(This branch can be removed after merge.)