### PR TITLE
Add confirmation message to inform that employee has passed

### DIFF
--- a/onboarding/src/Components/Employee/EmployeeFormPages/EmployeeFormPagesList.js
+++ b/onboarding/src/Components/Employee/EmployeeFormPages/EmployeeFormPagesList.js
@@ -5,7 +5,7 @@ import ProgressBar from "../../ProgressBar";
 
 
 const EmployeeFormPagesList = ({ pagesList, setPage, progress }) => {
-  const notStartedMsg = "Nie rozpoczęte", inProgressMsg = "W trakcie", finishedMsg = "Skończone";
+  const notStartedMsg = "Nie rozpoczęte", inProgressMsg = "W trakcie", finishedMsg = "Skończone", passedMsg = "Zaliczone";
 
   const pages = pagesList.map((page) => {
     let progressForPage = <ProgressBar backgroundSize={ "0%" } />, progressMsg = "Nie pobrano",
@@ -28,7 +28,11 @@ const EmployeeFormPagesList = ({ pagesList, setPage, progress }) => {
           percentage = "100%";
           // finishMsg = finishedMsg;
           progressForPage = <ProgressBar color={ "green" } backgroundSize={ percentage } />
-          progressMsg = <small className="ml-1">{ finishedMsg }</small>
+          if(localPage.confirmed)
+            progressMsg = <small className="ml-1">{ passedMsg }</small>
+          else
+            progressMsg = <small className="ml-1">{ finishedMsg }</small>
+
           page.isFinished = true;
         } else {
           percentage = "50%";


### PR DESCRIPTION
After applying this feature, employee will be informed that he has passed the test (or another form). Now he can only see "finished".
![Form is passed](https://user-images.githubusercontent.com/52573736/128692033-efba3690-ec1a-4ff0-a7d0-cafcbdf53713.jpg)

Magda's assignment to this `pull-request` is to let us know if we want to have this feature.
Now Only HR has this option (info. about confirmation).

(This branch can be removed after `merge`).